### PR TITLE
Add HW accelerated decoding for less CPU usage

### DIFF
--- a/mon.sh
+++ b/mon.sh
@@ -18,7 +18,7 @@ y=0
 	if [ -z "$name" ]; then
 		break
 	fi
-	mpv --mute=yes --geometry=${xsize}x${ysize}+$x+$y --window-scale=0.2 --osd-level=3  --osd-back-color=#000000 --osd-align-x=center --osd-margin-y=300 --osd-font-size=100 --osd-msg3="$name" --title="$name" --lavfi-complex='[aid1] asplit [t1] [ao] ; [t1] showvolume=w=1000:h=100 [t2] ; [vid1]  [t2]  overlay  [vo]' $url &
+	mpv --hwdec=auto --mute=yes --geometry=${xsize}x${ysize}+$x+$y --window-scale=0.2 --osd-level=3  --osd-back-color=#000000 --osd-align-x=center --osd-margin-y=300 --osd-font-size=100 --osd-msg3="$name" --title="$name" --lavfi-complex='[aid1] asplit [t1] [ao] ; [t1] showvolume=w=1000:h=100 [t2] ; [vid1]  [t2]  overlay  [vo]' $url &
 	let x=$x+$xsize
 	if [ $x -gt $xscreen ]; then
 		x=0


### PR DESCRIPTION
hwdec will fall back to software decoding if there is no available hardware decoding, so it shouldn't break the current behavior.